### PR TITLE
docs: 깃 언어분석 SCSS 제외

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.html linguist-detectable=false
 *.css linguist-detectable=false
+*.scss linguist-detectable=false


### PR DESCRIPTION
Git Rpository Language 분석에서 SCSS를 제외합니다.

현재 무시되는 언어
- HTML
- CSS
- SCSS