### PR TITLE
chore: module-web, module-admin 로컬 도커DB와 연동하기 위한 설정 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
         implementation 'com.h2database:h2:1.4.200'
+        runtimeOnly 'mysql:mysql-connector-java'
 
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
@@ -48,6 +49,11 @@ subprojects {
         testImplementation 'org.springframework.security:spring-security-test'
 
         implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    }
+}
+project(':module-admin') {
+    dependencies {
+        implementation project(':module-web')
     }
 }
 

--- a/module-admin/src/main/resources/application.yml
+++ b/module-admin/src/main/resources/application.yml
@@ -1,8 +1,10 @@
-server:
-  port: 8081
-
 spring:
+  profiles:
+    active: dev
   security:
     user:
       name: user
       password: 1111
+
+server:
+  port: 8081

--- a/module-web/src/main/java/web/order/controller/OrderController.java
+++ b/module-web/src/main/java/web/order/controller/OrderController.java
@@ -2,6 +2,6 @@ package web.order.controller;
 
 import org.springframework.stereotype.Controller;
 
-@Controller
+//@Controller
 public class OrderController {
 }

--- a/module-web/src/main/resources/application.yml
+++ b/module-web/src/main/resources/application.yml
@@ -2,19 +2,16 @@ spring:
   profiles:
     include:
       - auth
-
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
-
   h2:
     console:
       enabled: true
       path: /h2-console
-
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
+  datasource:
+    driver-class-name: com.mysql.jdbc.Driver
+    url: "jdbc:mysql://localhost:3306/testdb"
+    username: root
+    password: root


### PR DESCRIPTION
## 참고사항
- module-web은 개발환경, 운영환경을 아직 나누지 않았습니다.
- module-admin은 개발환경 프로파일을 따로 추출했습니다.
- OrderController라는 Bean이 두개 생성되어 에러가 발생해서 내용이 없는 컨트롤러를 우선 주석처리하였습니다.